### PR TITLE
Enable queue tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,10 @@ project(Flashmatch)
 set(CMAKE_CXX_STANDARD 23)
 
 # Library with core functionality
-add_library(flashmatch_lib flashmatch.cpp)
+add_library(flashmatch_lib
+  flashmatch.cpp
+  lock_free_queue.cpp
+)
 target_include_directories(flashmatch_lib PUBLIC ${PROJECT_SOURCE_DIR})
 
 add_executable(flashmatch main.cpp)

--- a/lock_free_queue.cpp
+++ b/lock_free_queue.cpp
@@ -35,3 +35,6 @@ template <typename T> T Atomic_Queue<T>::pop() {
   head_.store((h + 1) % capacity_, std::memory_order_release);
   return to_ret;
 }
+
+// Explicit instantiation for int to ensure template code is generated
+template class Atomic_Queue<int>;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,7 @@
-add_executable(flashmatch_tests test_main.cpp)
+add_executable(flashmatch_tests
+  test_main.cpp
+  test_lock_free_queue.cpp
+)
 
 target_link_libraries(flashmatch_tests PRIVATE
   flashmatch_lib


### PR DESCRIPTION
## Summary
- include `test_lock_free_queue.cpp` in the test build
- build lock-free queue implementation
- explicitly instantiate `Atomic_Queue<int>` so tests link

## Testing
- `cmake .. -G Ninja`
- `cmake --build .`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6877acc700188327a46c077dd5aaed2b