### PR TITLE
Add architecture build arg to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,51 +1,23 @@
-# To be executed to create the image for a processor with the x86 architecture.
-# FROM ubuntu:24.04
-#
-# ENV DEBIAN_FRONTEND=noninteractive
-#
-# # 1. Install essential build tools
-# RUN apt-get update && \
-#     apt-get install -y \
-#     build-essential cmake git curl wget ca-certificates && \
-#     rm -rf /var/lib/apt/lists/*
-#
-# # 2. Download Miniconda installer
-# RUN wget -O /tmp/miniconda.sh \
-#       https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
-#
-# # 3. Verify installer (optional; for debugging)
-# RUN head -n 5 /tmp/miniconda.sh
-#
-# # 4. Install Miniconda silently
-# RUN bash /tmp/miniconda.sh -b -p /opt/conda
-#
-# # 5. Cleanup installer
-# RUN rm /tmp/miniconda.sh
-#
-# ENV PATH=/opt/conda/bin:$PATH
-#
-# # 6. Install Python and libraries
-# RUN conda install -y python=3.11.5 matplotlib numpy && \
-#     conda clean -afy
-#
-# WORKDIR /workspace
-
 FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
+
+# Target architecture for Miniconda installer (arm64 or x86_64)
+ARG ARCH=arm64
 
 RUN apt-get update && \
     apt-get install -y build-essential cmake git curl wget ca-certificates vim && \
     rm -rf /var/lib/apt/lists/*
 
-RUN wget -O /tmp/miniconda.sh \
-    https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-aarch64.sh
-
-RUN head -n 5 /tmp/miniconda.sh
-
-RUN bash /tmp/miniconda.sh -b -p /opt/conda
-
-RUN rm /tmp/miniconda.sh
+# Map arm64 to aarch64 for the Linux installer
+RUN if [ "$ARCH" = "arm64" ]; then \
+        ARCH_URL="aarch64"; \
+    else \
+        ARCH_URL="$ARCH"; \
+    fi && \
+    wget -O /tmp/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-${ARCH_URL}.sh && \
+    bash /tmp/miniconda.sh -b -p /opt/conda && \
+    rm /tmp/miniconda.sh
 
 ENV PATH=/opt/conda/bin:$PATH
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,13 @@ Flashmatch is licensed under the [MIT](LICENSE) License.
 
 ## To Build image:
 
-docker build -t flashmatch:1
+The Dockerfile supports building for ARM64 (default) or x86_64. To specify an
+architecture, pass the `ARCH` build argument. For example, to build for x86_64:
+
+```bash
+docker build --build-arg ARCH=x86_64 -t flashmatch:1 .
+```
+If no architecture is supplied, the image is built for ARM64.
 
 ## To build & run container:
 


### PR DESCRIPTION
## Summary
- make architecture selectable in the Dockerfile
- document build argument usage in README

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6877b000d32c83279067e29136696766