### PR TITLE
Add ARCH build arg to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,37 +1,6 @@
-# To be executed to create the image for a processor with the x86 architecture.
-# FROM ubuntu:24.04
-#
-# ENV DEBIAN_FRONTEND=noninteractive
-#
-# # 1. Install essential build tools
-# RUN apt-get update && \
-#     apt-get install -y \
-#     build-essential cmake git curl wget ca-certificates && \
-#     rm -rf /var/lib/apt/lists/*
-#
-# # 2. Download Miniconda installer
-# RUN wget -O /tmp/miniconda.sh \
-#       https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
-#
-# # 3. Verify installer (optional; for debugging)
-# RUN head -n 5 /tmp/miniconda.sh
-#
-# # 4. Install Miniconda silently
-# RUN bash /tmp/miniconda.sh -b -p /opt/conda
-#
-# # 5. Cleanup installer
-# RUN rm /tmp/miniconda.sh
-#
-# ENV PATH=/opt/conda/bin:$PATH
-#
-# # 6. Install Python and libraries
-# RUN conda install -y python=3.11.5 matplotlib numpy && \
-#     conda clean -afy
-#
-# WORKDIR /workspace
-
 FROM ubuntu:24.04
 
+ARG ARCH=x86_64
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
@@ -39,13 +8,9 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 RUN wget -O /tmp/miniconda.sh \
-    https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-aarch64.sh
+    https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-${ARCH}.sh
 
-RUN head -n 5 /tmp/miniconda.sh
-
-RUN bash /tmp/miniconda.sh -b -p /opt/conda
-
-RUN rm /tmp/miniconda.sh
+RUN bash /tmp/miniconda.sh -b -p /opt/conda && rm /tmp/miniconda.sh
 
 ENV PATH=/opt/conda/bin:$PATH
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,17 @@ Flashmatch is licensed under the [MIT](LICENSE) License.
 
 ## To Build image:
 
-docker build -t flashmatch:1
+Choose the desired architecture when building the Docker image. For x86_64 run:
+
+```bash
+docker build --build-arg ARCH=x86_64 -t flashmatch:1 .
+```
+
+For ARM64 run:
+
+```bash
+docker build --build-arg ARCH=aarch64 -t flashmatch:1 .
+```
 
 ## To build & run container:
 


### PR DESCRIPTION
## Summary
- support `ARCH` build argument in Dockerfile for x86_64 or aarch64
- document how to build Docker image for each architecture

## Testing
- `cmake --build .`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6877b28d4a188327b685f18a478c7994