### PR TITLE
Refactor queue to ipp header implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,6 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # Library with core functionality
 add_library(flashmatch_lib
   src/flashmatch.cpp
-  src/lock_free_queue.cpp
 )
 
 target_include_directories(flashmatch_lib PUBLIC ${PROJECT_SOURCE_DIR}/include)

--- a/include/flashmatch/lock_free_queue.hpp
+++ b/include/flashmatch/lock_free_queue.hpp
@@ -22,3 +22,4 @@ public:
   T pop();
   bool isEmpty() const;
 };
+#include "lock_free_queue.ipp"

--- a/include/flashmatch/lock_free_queue.ipp
+++ b/include/flashmatch/lock_free_queue.ipp
@@ -1,4 +1,3 @@
-#include "flashmatch/lock_free_queue.hpp"
 #include <stdexcept>
 
 template <typename T>
@@ -36,5 +35,3 @@ template <typename T> T Atomic_Queue<T>::pop() {
   return to_ret;
 }
 
-// Explicit instantiation for int to ensure template code is generated
-template class Atomic_Queue<int>;


### PR DESCRIPTION
## Summary
- move `lock_free_queue` template implementation from CPP to an `ipp` file
- include the ipp file from `lock_free_queue.hpp`
- update `CMakeLists.txt` to stop compiling the old cpp source

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68639e031580832786e80871d99376b8