### PR TITLE
Update progress documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ From the repository root, run:
 ./build/flashmatch
 ```
 
+## Progress
+
+Days 1–4 complete. To benchmark, build and run `orderbook_bench`:
+
+```bash
+cmake --build . --target orderbook_bench
+./orderbook_bench <data_file>
+```
+
 ## License
 
 Flashmatch is licensed under the [MIT](LICENSE) License.


### PR DESCRIPTION
## Summary
- document Days 1-4 completion
- show how to build and run the `orderbook_bench` benchmark

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build`
- `cd build && ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68890665123083279e0e99220209ecb1