### PR TITLE
Add benchmark runner script

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ cmake --build . --target orderbook_bench
 ./orderbook_bench <data_file>
 ```
 
+To automate repeated runs and summarize latency metrics, use the helper
+script:
+
+```bash
+scripts/run_bench.sh <data_file> <iterations> [core]
+```
+
+The script appends each run's output to `bench.log` and prints the mean,
+median, and p99 latencies across all iterations.
+
 ## License
 
 Flashmatch is licensed under the [MIT](LICENSE) License.

--- a/scripts/run_bench.sh
+++ b/scripts/run_bench.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -lt 2 ]; then
+    echo "Usage: $0 <dataset> <iterations> [core]" >&2
+    exit 1
+fi
+
+dataset=$1
+iterations=$2
+core=${3:-0}
+log="bench.log"
+
+rm -f "$log"
+
+for i in $(seq 1 "$iterations"); do
+    echo "Run $i:" >> "$log"
+    if command -v taskset >/dev/null 2>&1; then
+        taskset -c "$core" ./orderbook_bench "$dataset" >> "$log"
+    else
+        ./orderbook_bench "$dataset" >> "$log"
+    fi
+done
+
+python3 - "$log" <<'PY' | tee -a "$log"
+import sys, re, statistics, numpy as np
+path = sys.argv[1]
+values = []
+with open(path) as f:
+    for line in f:
+        m = re.search(r"Mean latency:\s+([0-9.]+)", line)
+        if m:
+            values.append(float(m.group(1)))
+if values:
+    print("Summary over", len(values), "runs")
+    print("Mean:", statistics.mean(values))
+    print("Median:", statistics.median(values))
+    print("p99:", float(np.percentile(values, 99)))
+else:
+    print("No latency values found.")
+PY


### PR DESCRIPTION
## Summary
- Add `scripts/run_bench.sh` to automate multiple `orderbook_bench` runs, log results, and report aggregate metrics.
- Document usage of `run_bench.sh` in README.

## Testing
- `ctest`


------
https://chatgpt.com/codex/tasks/task_e_68938e2d24308327adca1376dd0dc2e3