### PR TITLE
chore: copy bench scripts into build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,4 +41,12 @@ FetchContent_MakeAvailable(googletest)
 
 enable_testing()
 include(GoogleTest)
+# Copy helper scripts into the build directory for convenience
+add_custom_target(copy_scripts ALL
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+            ${CMAKE_SOURCE_DIR}/scripts
+            ${CMAKE_BINARY_DIR}/scripts
+    COMMENT "Copying scripts to build directory"
+)
+
 add_subdirectory(tests)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To automate repeated runs and summarize latency metrics, use the helper
 script:
 
 ```bash
-scripts/run_bench.sh <data_file> <iterations> [core]
+./build/scripts/run_bench.sh <data_file> <iterations> [core]
 ```
 
 The script appends each run's output to `bench.log` and prints the mean,

--- a/scripts/run_bench.sh
+++ b/scripts/run_bench.sh
@@ -11,14 +11,21 @@ iterations=$2
 core=${3:-0}
 log="bench.log"
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exe="${SCRIPT_DIR}/../orderbook_bench"
+if [ ! -x "$exe" ]; then
+    echo "Executable not found: $exe" >&2
+    exit 1
+fi
+
 rm -f "$log"
 
 for i in $(seq 1 "$iterations"); do
     echo "Run $i:" >> "$log"
     if command -v taskset >/dev/null 2>&1; then
-        taskset -c "$core" ./orderbook_bench "$dataset" >> "$log"
+        taskset -c "$core" "$exe" "$dataset" >> "$log"
     else
-        ./orderbook_bench "$dataset" >> "$log"
+        "$exe" "$dataset" >> "$log"
     fi
 done
 


### PR DESCRIPTION
## Summary
- copy helper scripts to the CMake build directory
- ensure run_bench.sh locates orderbook_bench relative to its location
- document new script path in README

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest`

------
https://chatgpt.com/codex/tasks/task_e_68934dad3d40832799719f542fa40032