### PR TITLE
Use insert for benchmark warmup and refine bench helper

### DIFF
--- a/scripts/run_bench.sh
+++ b/scripts/run_bench.sh
@@ -30,19 +30,28 @@ for i in $(seq 1 "$iterations"); do
 done
 
 python3 - "$log" <<'PY' | tee -a "$log"
-import sys, re, statistics, numpy as np
+import sys, re, statistics
+
 path = sys.argv[1]
 values = []
+
 with open(path) as f:
     for line in f:
-        m = re.search(r"Mean latency:\s+([0-9.]+)", line)
-        if m:
-            values.append(float(m.group(1)))
+        match = re.search(r"Mean latency:\s+([0-9.]+)", line)
+        if match:
+            values.append(float(match.group(1)))
+
 if values:
-    print("Summary over", len(values), "runs")
-    print("Mean:", statistics.mean(values))
-    print("Median:", statistics.median(values))
-    print("p99:", float(np.percentile(values, 99)))
+    mean = statistics.mean(values)
+    median = statistics.median(values)
+    try:
+        p99 = statistics.quantiles(values, n=100)[98]
+    except statistics.StatisticsError:
+        p99 = values[-1]
+    print(f"Summary over {len(values)} runs")
+    print(f"Mean: {mean}")
+    print(f"Median: {median}")
+    print(f"p99: {p99}")
 else:
     print("No latency values found.")
 PY

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -106,7 +106,9 @@ stats_t run_bench(const std::string &filename) {
       std::cout << "Failed to parse line: " << warmup_line << std::endl;
       break;
     }
-    engine.submit(new_order);
+    // Prefill the matching engine without triggering any matching logic so that
+    // subsequent benchmark orders run against a fully populated book.
+    engine.insert(new_order);
     ++warmup_ct;
   }
 


### PR DESCRIPTION
## Summary
- prefill matching engine using `insert` during benchmark warmup so orders don't match prematurely
- simplify `run_bench.sh` to compute mean/median/p99 using only Python's standard library

## Testing
- `ctest --test-dir build`
- `./build/scripts/run_bench.sh small.csv 3`


------
https://chatgpt.com/codex/tasks/task_e_689431fd2d188327b4abb49a71becd6d