### PR TITLE
Add gRPC order gateway server and client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,16 +111,14 @@ target_link_libraries(orderbook_bench PRIVATE flashmatch_lib)
 target_compile_options(orderbook_bench PRIVATE -O3 -march=native)
 set_property(TARGET orderbook_bench PROPERTY CXX_STANDARD 20)
 
-# The gRPC server and client executables are commented out because
-# their source files are empty. Uncomment these when you implement them.
+# gRPC server and client examples
+add_executable(order_gateway_server src/order_gateway_server.cpp)
+target_link_libraries(order_gateway_server PRIVATE order_gateway_proto lock_free_queue gRPC::grpc++)
+set_property(TARGET order_gateway_server PROPERTY CXX_STANDARD 20)
 
-# add_executable(order_gateway_server src/order_gateway_server.cpp)
-# target_link_libraries(order_gateway_server PRIVATE order_gateway_proto lock_free_queue gRPC::grpc++)
-# set_property(TARGET order_gateway_server PROPERTY CXX_STANDARD 20)
-
-# add_executable(order_gateway_client src/order_gateway_client.cpp)
-# target_link_libraries(order_gateway_client PRIVATE order_gateway_proto gRPC::grpc++)
-# set_property(TARGET order_gateway_client PROPERTY CXX_STANDARD 20)
+add_executable(order_gateway_client src/order_gateway_client.cpp)
+target_link_libraries(order_gateway_client PRIVATE order_gateway_proto gRPC::grpc++)
+set_property(TARGET order_gateway_client PROPERTY CXX_STANDARD 20)
 
 # ---- Tests --------------------------------------------------------------------
 include(CTest)

--- a/include/flashmatch/order_queue.hpp
+++ b/include/flashmatch/order_queue.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "lock_free_queue/lock_free_queue.hpp"
+#include "types/order.hpp"
+
+// Global lock-free queue used by the order gateway server.
+// The queue is defined as an inline variable so it can be
+// shared across translation units without requiring a
+// separate definition.
+inline lfq::Atomic_Queue<Order> g_order_queue{1024};
+

--- a/src/order_gateway_client.cpp
+++ b/src/order_gateway_client.cpp
@@ -1,3 +1,31 @@
-int main(int argc, char** argv) {
+#include <iostream>
+
+#include <grpcpp/grpcpp.h>
+
+#include "order_gateway.grpc.pb.h"
+
+int main() {
+  const std::string target_str{"localhost:50051"};
+  auto channel = grpc::CreateChannel(target_str, grpc::InsecureChannelCredentials());
+  std::unique_ptr<flashmatch::OrderGateway::Stub> stub = flashmatch::OrderGateway::NewStub(channel);
+
+  flashmatch::Order order;
+  order.set_id(1);
+  order.set_symbol("AAPL");
+  order.set_side(flashmatch::BUY);
+  order.set_price(100.0);
+  order.set_quantity(10);
+  order.set_type(flashmatch::LIMIT);
+
+  flashmatch::Ack ack;
+  grpc::ClientContext context;
+  grpc::Status status = stub->SubmitOrder(&context, order, &ack);
+
+  if (status.ok()) {
+    std::cout << "Ack ok: " << ack.ok() << std::endl;
+  } else {
+    std::cerr << "RPC failed: " << status.error_message() << std::endl;
+  }
+
   return 0;
 }

--- a/src/order_gateway_server.cpp
+++ b/src/order_gateway_server.cpp
@@ -1,3 +1,41 @@
-int main(int argc, char* argv[]) {
+#include <iostream>
+
+#include <grpcpp/grpcpp.h>
+
+#include "flashmatch/order_queue.hpp"
+#include "order_gateway.grpc.pb.h"
+#include "types/ordertype.hpp"
+#include "types/side.hpp"
+
+class OrderGatewayService final : public flashmatch::OrderGateway::Service {
+public:
+  grpc::Status SubmitOrder(grpc::ServerContext *context,
+                           const flashmatch::Order *request,
+                           flashmatch::Ack *response) override {
+    Order order{
+        request->id(),
+        request->symbol(),
+        request->side() == flashmatch::BUY ? Side::BUY : Side::SELL,
+        request->price(),
+        request->quantity(),
+        request->type() == flashmatch::LIMIT ? OrderType::LIMIT : OrderType::IOC};
+
+    bool pushed = g_order_queue.push(order);
+    response->set_ok(pushed);
+    return grpc::Status::OK;
+  }
+};
+
+int main() {
+  const std::string server_address{"0.0.0.0:50051"};
+  OrderGatewayService service;
+
+  grpc::ServerBuilder builder;
+  builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
+  builder.RegisterService(&service);
+
+  std::unique_ptr<grpc::Server> server(builder.BuildAndStart());
+  std::cout << "Server listening on " << server_address << std::endl;
+  server->Wait();
   return 0;
 }


### PR DESCRIPTION
## Summary
- add global lock-free order queue
- implement gRPC OrderGateway server that enqueues orders
- add sample client to submit an order and print ACK
- build server and client executables linking to order_gateway_proto and gRPC

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest`


------
https://chatgpt.com/codex/tasks/task_e_68990144c7f88327a19e04359784c55b