### PR TITLE
Ensure dataset generation succeeds in benchmark tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,25 +85,17 @@ jobs:
           docker inspect -f '{{.State.Status}} {{.Config.Image}} {{.Name}}' flashmatch-ci
           docker exec flashmatch-ci uname -m
 
-     # ---------- FIX: install psutil the Debian way ----------
-      - name: Install psutil via apt (PEP 668-safe)
+      # ---------------------------------------------------------------
+      # TEMP: install Python deps needed for dataset generation. These
+      # should be baked into the Docker image in future revisions.
+      # ---------------------------------------------------------------
+      - name: Install Python dependencies
         run: |
           docker exec flashmatch-ci bash -lc '
             set -e
             apt-get update
-            apt-get install -y python3-psutil python3-venv
-            python3 -c "import psutil; print(\"psutil=\", psutil.__version__)"
-          '
-
-      # ---------- Use a venv for pip-installed deps ----------
-      - name: Create venv & install Python dependencies
-        run: |
-          docker exec flashmatch-ci bash -lc '
-            set -e
-            python3 -m venv .venv
-            . .venv/bin/activate
-            python -m pip install --upgrade pip
-            pip install -r datasets/requirements.txt
+            apt-get install -y python3-pip
+            pip3 install --no-cache-dir -r datasets/requirements.txt
           '
 
       - name: Show container logs if it exits

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
       python3-numpy \
       python3-matplotlib \
       python3-pandas \
+      python3-tqdm \
+      python3-psutil \
     && rm -rf /var/lib/apt/lists/*
 
 # Natural python/pip names

--- a/tests/benchmark_test.cpp
+++ b/tests/benchmark_test.cpp
@@ -27,7 +27,8 @@ protected:
           (std::filesystem::path(__FILE__).parent_path() / ".." / "datasets")
               .string() +
           " && python3 generate_orderbook.py)";
-      std::system(cmd.c_str());
+      int result = std::system(cmd.c_str());
+      ASSERT_EQ(result, 0) << "Dataset generation failed with code " << result;
     }
     ASSERT_TRUE(std::filesystem::exists(path))
         << "Dataset missing after generation";


### PR DESCRIPTION
## Summary
- verify dataset generation succeeds in benchmark tests by checking system() return code
- install tqdm and psutil in container image so dataset generation script runs
- install dataset generation Python dependencies in CI workflow, noting they should eventually live in Docker image

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build -j$(nproc)` *(fails: google/protobuf/runtime_version.h missing)*


------
https://chatgpt.com/codex/tasks/task_e_68a3a7039dd08327a7283affd0ac94c1